### PR TITLE
Goblin attacks are much more fluid, Telegraph goblin attacks, Add goblin boss

### DIFF
--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyAttackingState.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyAttackingState.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 public class EnemyAttackingState : EnemyBaseState
 {
-    private readonly int AnimatorAttackStateName = Animator.StringToHash("Attack1SwordShield");
+    private readonly int AnimatorAttackStateName = Animator.StringToHash("Attack2SwordShield");
+    private readonly int DefaultEmptyStateName = Animator.StringToHash("Default Empty");
 
     private const float TransitionDuration = 0.1f;
 
@@ -15,13 +16,18 @@ public class EnemyAttackingState : EnemyBaseState
     public override void Enter()
     {
         stateMachine.WeaponDamager.SetDamage(stateMachine.AttackDamage);
-
-        stateMachine.Animator.CrossFadeInFixedTime(AnimatorAttackStateName, TransitionDuration);
+        stateMachine.Animator.CrossFadeInFixedTime(AnimatorAttackStateName, TransitionDuration, 1);
     }
 
     public override void Tick(float deltaTime)
     {
-        if (GetPlayingAnimationTimeNormalized(stateMachine.Animator) >= 1.0f)
+        MoveToPlayer(deltaTime);
+
+        FacePlayer();
+
+        UpdateAnimator(deltaTime);
+
+        if (GetPlayingAnimationTimeNormalized(stateMachine.Animator, 1) >= 1.0f)
         {
             stateMachine.SwitchState(new EnemyChasingState(stateMachine));
         }
@@ -29,5 +35,6 @@ public class EnemyAttackingState : EnemyBaseState
 
     public override void Exit()
     {
+        stateMachine.Animator.CrossFade(DefaultEmptyStateName, TransitionDuration, 1); // without this, gets stuck at end of attack animation
     }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyBaseState.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyBaseState.cs
@@ -6,6 +6,9 @@ public abstract class EnemyBaseState : State
 {
     protected EnemyStateMachine stateMachine;
 
+    private readonly int AnimatorSpeedParam = Animator.StringToHash("Speed");
+    private const float AnimatorDampTime = 0.1f;
+
     public EnemyBaseState(EnemyStateMachine stateMachine)
     {
         this.stateMachine = stateMachine;
@@ -19,6 +22,15 @@ public abstract class EnemyBaseState : State
     protected void Move(float deltaTime)
     {
         Move(Vector3.zero, deltaTime);
+    }
+
+    protected void MoveToPlayer(float deltaTime)
+    {
+        stateMachine.NavMeshAgent.destination = stateMachine.Player.transform.position;
+
+        Move(stateMachine.NavMeshAgent.desiredVelocity.normalized * stateMachine.MovementSpeed, deltaTime);
+
+        stateMachine.NavMeshAgent.velocity = stateMachine.CharacterController.velocity; // needed to sync velocities
     }
 
     protected void FacePlayer()
@@ -45,5 +57,17 @@ public abstract class EnemyBaseState : State
             stateMachine.transform.position).sqrMagnitude;
 
         return distanceToPlayerSqr <= stateMachine.AttackRange * stateMachine.AttackRange;
+    }
+
+    protected void UpdateAnimator(float deltaTime)
+    {
+        if (stateMachine.NavMeshAgent.velocity != Vector3.zero)
+        {
+            stateMachine.Animator.SetFloat(AnimatorSpeedParam, 1.0f, AnimatorDampTime, deltaTime);
+        }
+        else
+        {
+            stateMachine.Animator.SetFloat(AnimatorSpeedParam, 0.0f, AnimatorDampTime, deltaTime);
+        }
     }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyChasingState.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyChasingState.cs
@@ -5,10 +5,8 @@ using UnityEngine;
 public class EnemyChasingState : EnemyBaseState
 {
     private readonly int LocomotionStateName = Animator.StringToHash("Locomotion");
-    private readonly int AnimatorSpeedParam = Animator.StringToHash("Speed");
-
+    
     private const float CrossFadeDuration = 0.1f;
-    private const float AnimatorDampTime = 0.1f;
 
     public EnemyChasingState(EnemyStateMachine stateMachine) : base(stateMachine)
     {
@@ -16,7 +14,7 @@ public class EnemyChasingState : EnemyBaseState
 
     public override void Enter()
     {
-        stateMachine.Animator.CrossFadeInFixedTime(LocomotionStateName, CrossFadeDuration);
+        stateMachine.Animator.CrossFadeInFixedTime(LocomotionStateName, CrossFadeDuration, -1);
     }
 
     public override void Tick(float deltaTime)
@@ -36,21 +34,12 @@ public class EnemyChasingState : EnemyBaseState
 
         FacePlayer();
 
-        stateMachine.Animator.SetFloat(AnimatorSpeedParam, 1.0f, AnimatorDampTime, deltaTime);
+        UpdateAnimator(deltaTime);
     }
 
     public override void Exit()
     {
         stateMachine.NavMeshAgent.ResetPath();
         stateMachine.NavMeshAgent.velocity = Vector3.zero;
-    }
-
-    private void MoveToPlayer(float deltaTime)
-    {
-        stateMachine.NavMeshAgent.destination = stateMachine.Player.transform.position;
-
-        Move(stateMachine.NavMeshAgent.desiredVelocity.normalized * stateMachine.MovementSpeed, deltaTime);
-
-        stateMachine.NavMeshAgent.velocity = stateMachine.CharacterController.velocity; // needed to sync velocities
     }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyIdleState.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Enemy/EnemyIdleState.cs
@@ -5,10 +5,8 @@ using UnityEngine;
 public class EnemyIdleState : EnemyBaseState
 {
     private readonly int LocomotionStateName = Animator.StringToHash("Locomotion");
-    private readonly int AnimatorSpeedParam = Animator.StringToHash("Speed");
 
     private const float CrossFadeDuration = 0.1f;
-    private const float AnimatorDampTime = 0.1f;
 
     public EnemyIdleState(EnemyStateMachine stateMachine) : base(stateMachine)
     {
@@ -30,8 +28,6 @@ public class EnemyIdleState : EnemyBaseState
         }
 
         FacePlayer();
-
-        stateMachine.Animator.SetFloat(AnimatorSpeedParam, 0.0f, AnimatorDampTime, deltaTime); // updates blend tree state
     }
 
     public override void Exit()

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/State.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/State.cs
@@ -12,16 +12,16 @@ public abstract class State
     /// Gets the currently playing animation's duration played no matter how long the animation is.
     /// </summary>
     /// <returns>0.0f to 1.0f where 1.0f represents 100% of animation played</returns>
-    protected float GetPlayingAnimationTimeNormalized(Animator animator)
+    protected float GetPlayingAnimationTimeNormalized(Animator animator, int layerIndex)
     {
-        AnimatorStateInfo currentInfo = animator.GetCurrentAnimatorStateInfo(0);
-        AnimatorStateInfo nextInfo = animator.GetNextAnimatorStateInfo(0);
+        AnimatorStateInfo currentInfo = animator.GetCurrentAnimatorStateInfo(layerIndex);
+        AnimatorStateInfo nextInfo = animator.GetNextAnimatorStateInfo(layerIndex);
 
-        if (animator.IsInTransition(0) && nextInfo.IsTag("Attack"))
+        if (animator.IsInTransition(layerIndex) && nextInfo.IsTag("Attack"))
         {
             return nextInfo.normalizedTime;
         }
-        else if (!animator.IsInTransition(0) && currentInfo.IsTag("Attack"))
+        else if (!animator.IsInTransition(layerIndex) && currentInfo.IsTag("Attack"))
         {
             return currentInfo.normalizedTime;
         }


### PR DESCRIPTION
Allow goblins to move while attacking, always facing the player. Attack and running animations play smoothly simultaneously using avatar mask. Goblin attack animations are slower and more telegraphed. Duplicated and enlarged goblin to make goblin boss.