### PR TITLE
Settings Menu - Difficulty Settings

### DIFF
--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
@@ -4,13 +4,45 @@ using UnityEngine.UI;
 public class SettingsManager : MonoBehaviour
 {
     public Toggle godModeToggle;
+    public Dropdown difficultyDropdown;
 
     void Start()
     {
         godModeToggle.onValueChanged.AddListener( delegate { ToggleGodMode( godModeToggle.isOn ); } );
+        difficultyDropdown.onValueChanged.AddListener( delegate { DifficultyChanged( difficultyDropdown.value ); } );
     }
 
-    public void ToggleGodMode( bool isOn )
+    public void DifficultyChanged( int difficultyIndex )
+    {
+        PlayerPrefs.SetInt( "SelectedDifficulty", difficultyIndex );
+        PlayerPrefs.Save();
+
+        ApplyDifficultySetting( difficultyIndex );
+
+    }
+
+    // Maybe you can do your difficulty implementation here, or do it in the other scene's code somewhere.
+    void ApplyDifficultySetting( int difficultyIndex )
+    {
+        switch ( difficultyIndex )
+        {
+            case 0: // Easy
+                //SetMonsterDamage( EasyDamageValue );
+                Debug.Log( "ez difficulty" );
+                break;
+            case 1: // Hard
+                    //SetMonsterDamage( MediumDamageValue );
+                Debug.Log( "medium difficulty" );
+                break;
+            case 2: // Almost Impossible
+                    //SetMonsterDamage( HardDamageValue );
+                Debug.Log( "hard difficulty" );
+                break;
+        }
+    }
+
+
+public void ToggleGodMode( bool isOn )
     {
         PlayerPrefs.SetInt( "GodMode", isOn ? 1 : 0 );
     }


### PR DESCRIPTION
If you do not want to implement your difficulty changes in that settings file, you can easily use the playerprefs code below anywhere else to appropriately set your difficulty

`Debug.Log( "my playerpref is currently: " + PlayerPrefs.GetInt( "SelectedDifficulty", 0 ) );`

Have to pull latest from Perfoce, there is changes to the Main Menu scene. 

Delete the function I implemented     `ApplyDifficultySetting( int difficultyIndex )` if you are not going to use it there :) 