### PR TITLE
Softcore & Menu Fixes, Additional Tutorial Images

### DIFF
--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/GameOverScreen.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/GameOverScreen.cs
@@ -9,9 +9,6 @@ public class GameOverScreen : MonoBehaviour
 
     public void Setup( float durationAlive )
     {
-        // Update current level player pref for softcore
-        PlayerPrefs.SetInt("SCCurrentLevel", FindFirstObjectByType<LevelManager>().CurrentLevelIndex);
-        Debug.Log(PlayerPrefs.GetInt("SCCurrentLevel"));
         gameObject.SetActive( true );
 
         Cursor.lockState = CursorLockMode.None;

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/GameOverScreen.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/GameOverScreen.cs
@@ -9,6 +9,9 @@ public class GameOverScreen : MonoBehaviour
 
     public void Setup( float durationAlive )
     {
+        // Update current level player pref for softcore
+        PlayerPrefs.SetInt("SCCurrentLevel", FindFirstObjectByType<LevelManager>().CurrentLevelIndex);
+        Debug.Log(PlayerPrefs.GetInt("SCCurrentLevel"));
         gameObject.SetActive( true );
 
         Cursor.lockState = CursorLockMode.None;
@@ -22,8 +25,6 @@ public class GameOverScreen : MonoBehaviour
 
     public void RestartGameButton()
     {
-        // Save the current level index for softcore
-        PlayerPrefs.SetInt("SCCurrentLevel", FindFirstObjectByType<LevelManager>().CurrentLevelIndex);
         // Get the name of the current scene
         string currentSceneName = SceneManager.GetActiveScene().name;
 

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/LevelManager.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/LevelManager.cs
@@ -75,7 +75,6 @@ public class LevelManager : MonoBehaviour
             Debug.Log("Invalid Level index");
             return;
         }
-
         StartLevel();
     }
 

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
@@ -28,6 +28,7 @@ public class Menu : MonoBehaviour
 
         // Set Difficulty Dropdown based on PlayerPrefs
         int selectedDifficulty = PlayerPrefs.GetInt("SelectedDifficulty", 0);
+        Debug.Log(selectedDifficulty);
         DifficultyDropdown.value = selectedDifficulty;
 
         // Reset last known level in softcore mode

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
@@ -1,4 +1,3 @@
-using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,6 +14,10 @@ public class Menu : MonoBehaviour
 
     void LoadSettings()
     {
+        // Mute menu sounds until all settings are loaded from playerprefs 
+        AudioSource menuSounds = FindFirstObjectByType<GUISoundManager>().GetComponent<AudioSource>();
+        menuSounds.mute = true;
+
         // Set God Mode Toggle based on PlayerPrefs
         bool godModeEnabled = PlayerPrefs.GetInt("GodMode", 0) == 1;
         GodModeToggle.isOn = godModeEnabled;
@@ -26,6 +29,12 @@ public class Menu : MonoBehaviour
         // Set Difficulty Dropdown based on PlayerPrefs
         int selectedDifficulty = PlayerPrefs.GetInt("SelectedDifficulty", 0);
         DifficultyDropdown.value = selectedDifficulty;
+
+        // Reset last known level in softcore mode
+        PlayerPrefs.SetInt("SCCurrentLevel", 0);
+
+        // Unmute menu sounds when done
+        menuSounds.mute = false;
     }
 
     public void ExitGame()

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
@@ -24,7 +24,6 @@ public class Menu : MonoBehaviour
 
         // Set Difficulty Dropdown based on PlayerPrefs
         int selectedDifficulty = PlayerPrefs.GetInt("SelectedDifficulty", 0);
-        Debug.Log(selectedDifficulty);
         DifficultyDropdown.value = selectedDifficulty;
 
         // Reset last known level in softcore mode

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/Menu.cs
@@ -14,10 +14,6 @@ public class Menu : MonoBehaviour
 
     void LoadSettings()
     {
-        // Mute menu sounds until all settings are loaded from playerprefs 
-        AudioSource menuSounds = FindFirstObjectByType<GUISoundManager>().GetComponent<AudioSource>();
-        menuSounds.mute = true;
-
         // Set God Mode Toggle based on PlayerPrefs
         bool godModeEnabled = PlayerPrefs.GetInt("GodMode", 0) == 1;
         GodModeToggle.isOn = godModeEnabled;
@@ -33,9 +29,6 @@ public class Menu : MonoBehaviour
 
         // Reset last known level in softcore mode
         PlayerPrefs.SetInt("SCCurrentLevel", 0);
-
-        // Unmute menu sounds when done
-        menuSounds.mute = false;
     }
 
     public void ExitGame()

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
@@ -7,12 +7,15 @@ public class SettingsManager : MonoBehaviour
     public Toggle softcoreToggle;
     public Dropdown difficultyDropdown;
     private int previousDifficultyIndex = -1;
+    public GUISoundManager soundManager;
 
     void Start()
     {
+
         difficultyDropdown.onValueChanged.AddListener( delegate { DifficultyChanged(); } );
         softcoreToggle.onValueChanged.AddListener( delegate { ToggleSoftcore(); });
         godModeToggle.onValueChanged.AddListener( delegate { ToggleGodMode(); } );
+        soundManager = FindFirstObjectByType<GUISoundManager>();
     }
 
     public void DifficultyChanged()
@@ -25,15 +28,21 @@ public class SettingsManager : MonoBehaviour
 
             previousDifficultyIndex = difficultyIndex;
         }
+        if (difficultyDropdown.isActiveAndEnabled)
+            soundManager.PlaySelectConfirmation();
     }
 
     public void ToggleGodMode()
     {
         PlayerPrefs.SetInt( "GodMode", godModeToggle.isOn ? 1 : 0 );
+        if (godModeToggle.isActiveAndEnabled)
+            soundManager.PlaySelectConfirmation();
     }
 
     public void ToggleSoftcore()
     {
         PlayerPrefs.SetInt("Softcore", softcoreToggle.isOn ? 1 : 0);
+        if (softcoreToggle.isActiveAndEnabled)
+            soundManager.PlaySelectConfirmation();
     }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/SettingsManager.cs
@@ -10,52 +10,30 @@ public class SettingsManager : MonoBehaviour
 
     void Start()
     {
-        difficultyDropdown.onValueChanged.AddListener( delegate { DifficultyChanged( difficultyDropdown.value ); } );
-        softcoreToggle.onValueChanged.AddListener(delegate { ToggleSoftcore(softcoreToggle.isOn); });
-        godModeToggle.onValueChanged.AddListener( delegate { ToggleGodMode( godModeToggle.isOn ); } );
+        difficultyDropdown.onValueChanged.AddListener( delegate { DifficultyChanged(); } );
+        softcoreToggle.onValueChanged.AddListener( delegate { ToggleSoftcore(); });
+        godModeToggle.onValueChanged.AddListener( delegate { ToggleGodMode(); } );
     }
 
-    public void DifficultyChanged( int difficultyIndex )
+    public void DifficultyChanged()
     {
+        int difficultyIndex = difficultyDropdown.value;
         if (difficultyIndex != previousDifficultyIndex)
         {
             PlayerPrefs.SetInt("SelectedDifficulty", difficultyIndex);
             PlayerPrefs.Save();
 
-            ApplyDifficultySetting(difficultyIndex);
-
             previousDifficultyIndex = difficultyIndex;
         }
     }
 
-    // Maybe you can do your difficulty implementation here, or do it in the other scene's code somewhere.
-    void ApplyDifficultySetting( int difficultyIndex )
+    public void ToggleGodMode()
     {
-        switch ( difficultyIndex )
-        {
-            case 0: // Easy
-                //SetMonsterDamage( EasyDamageValue );
-                Debug.Log( "ez difficulty" );
-                break;
-            case 1: // Hard
-                    //SetMonsterDamage( MediumDamageValue );
-                Debug.Log( "medium difficulty" );
-                break;
-            case 2: // Almost Impossible
-                    //SetMonsterDamage( HardDamageValue );
-                Debug.Log( "hard difficulty" );
-                break;
-        }
+        PlayerPrefs.SetInt( "GodMode", godModeToggle.isOn ? 1 : 0 );
     }
 
-
-    public void ToggleGodMode( bool isOn )
+    public void ToggleSoftcore()
     {
-        PlayerPrefs.SetInt( "GodMode", isOn ? 1 : 0 );
-    }
-
-    public void ToggleSoftcore(bool isOn)
-    {
-        PlayerPrefs.SetInt("Softcore", isOn ? 1 : 0);
+        PlayerPrefs.SetInt("Softcore", softcoreToggle.isOn ? 1 : 0);
     }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Dragon/DragonStateMachine.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Dragon/DragonStateMachine.cs
@@ -197,6 +197,7 @@ public class DragonStateMachine : StateMachine
     private void HandleDie()
     {
         ProjectileShooter.ShooterDied();
+        PlayerPrefs.SetInt("SCCurrentLevel", 0);
         Invoke( "GameComplete", 10.0f );
         SwitchState(new DragonDeadState(this));
     }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
@@ -97,7 +97,6 @@ public class PlayerStateMachine : StateMachine
     {
         // Update current level player pref for softcore
         PlayerPrefs.SetInt("SCCurrentLevel", FindFirstObjectByType<LevelManager>().CurrentLevelIndex);
-        Debug.Log(PlayerPrefs.GetInt("SCCurrentLevel"));
         Invoke( "GameOver", 3.0f );
         SwitchState(new PlayerDeadState(this));
     }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
@@ -95,6 +95,9 @@ public class PlayerStateMachine : StateMachine
 
     private void HandleDie()
     {
+        // Update current level player pref for softcore
+        PlayerPrefs.SetInt("SCCurrentLevel", FindFirstObjectByType<LevelManager>().CurrentLevelIndex);
+        Debug.Log(PlayerPrefs.GetInt("SCCurrentLevel"));
         Invoke( "GameOver", 3.0f );
         SwitchState(new PlayerDeadState(this));
     }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerUsingHealState.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerUsingHealState.cs
@@ -28,7 +28,6 @@ public class PlayerUsingHealState : PlayerBaseState
         if (GetPlayingAnimationTimeNormalized(stateMachine.Animator, 1) >= 0.7f) // make comparing with less than (1.0f - Transition Duration) in Animator Transition Settings
         {
             stateMachine.HealthConsumable.Use();
-            Debug.Log("used heal!");
             stateMachine.VFXHealing.SetActive(false);
             stateMachine.SwitchState(new PlayerDefaultState(stateMachine));
             return;


### PR DESCRIPTION
# Softcore Fixes
`PlayerPrefs.SCCurrentLevel` is used to keep track of which level to restart on if the player dies. It was behaving inconsistently because of a relatively naive implementation. These are the places where it changes now:
- `PlayerStateMachine.HandleDie` set the level the player dies on here
- `DragonStateMachine.HandleDie` reset the current level back to 1 when the dragon dies to when we click restart it goes back to the beginning
- `Menu.LoadSettings` reset the current level back to 1 when the player returns to the menu
## Restart Behavior
- On hardcore (default), always start from the first level
- On softcore, when clicking restart on death, restart at the current level
- On softcore, when clicking restart on dragon kill, restart at first level
- On softcore, returning to main menu and playing again restarts at the first level
# Menu Fixes
- Removed argument from the `onValueChanged` listeners for all the settings, instead read the values directly from the UI elements. Because the original implementations took an argument, the `onValueChanged` method directly attached to the UI element in the hierarchy had to pass a value (default 0) which conflicts with the UI element's value. This causes problems when the menu scene is first loaded as despite correctly reading in the player prefs and setting the UI element values properly, the actual value was set to 0s behind the scenes resulting in normal difficulty settings even though the dropdown might say hard/impossible
- Changed `GUISoundManager.Start` to `GUISoundManager.Awake` so the audio source gets loaded in time before the start methods of various menu scripts. This was causing an error on scene start that errored out in the middle of `Menu.LoadSettings`, causing a failure to load the player prefs and update the relevant UI elements correctly.