### PR TITLE
Make impossible difficulty barely possible and tune for pacing, make lower difficulties slightly harder, fix some immersion-breaking bugs

### DIFF
--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/DifficultyAdjustments.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/DifficultyAdjustments.cs
@@ -12,10 +12,10 @@ public class DifficultyAdjustments : MonoBehaviour
     private void Awake()
     {
         Player = GameObject.FindGameObjectWithTag("Player");
+        PlayerStateMachine PlayerStateMachine = Player.GetComponent<PlayerStateMachine>();
         Health PlayerHealth = Player.GetComponent<Health>();
         HealthConsumable HealthConsumable = Player.GetComponent<HealthConsumable>();
         ShieldController ShieldController = Player.GetComponent<ShieldController>();
-        
         switch (PlayerPrefs.GetInt("SelectedDifficulty"))
         {
             case 0:
@@ -26,13 +26,15 @@ public class DifficultyAdjustments : MonoBehaviour
                 MemoryAttack.memAtkCost = 30;
                 ShieldCollisions.SetParryRates(12, 15, 4);
                 ShieldController.SetShieldRates(1, 30, 10, 0.3f);
+                // Player mobility adjustment
+                PlayerStateMachine.SetMovementSpeed(5f);
                 // Summon up to 10 units, summon every 12 seconds, can 1-shot with memory attack immediately.
                 EnemyPortal.DifficultyAdjustment(100, 10, 10);
                 // Boss health adjustments
                 MeleeStateMachine.BossHP = 500;
                 TormentedSoulStateMachine.BossHP = 500;
                 MagicStateMachine.BossHP = 500;
-                DragonStateMachine.BossHP = 1500;
+                DragonStateMachine.BossHP = 1200;
                 // Dragon specific adjustments
                 DragonStateMachine.BomberCount = 2;
                 break;
@@ -44,13 +46,15 @@ public class DifficultyAdjustments : MonoBehaviour
                 MemoryAttack.memAtkCost = 50;
                 ShieldCollisions.SetParryRates(8, 12, 3);
                 ShieldController.SetShieldRates(1.5f, 25, 15, 0.6f);
+                // Player mobility adjustment
+                PlayerStateMachine.SetMovementSpeed(4.5f);
                 // Summon up to 14 units, summon every 10 seconds.
                 EnemyPortal.DifficultyAdjustment(140, 10, 6);
                 // Boss health adjustments
                 MeleeStateMachine.BossHP = 700;
                 TormentedSoulStateMachine.BossHP = 700;
                 MagicStateMachine.BossHP = 700;
-                DragonStateMachine.BossHP = 1700;
+                DragonStateMachine.BossHP = 1600;
                 // Dragon specific adjustments
                 DragonStateMachine.BomberCount = 3;
                 break;
@@ -62,6 +66,8 @@ public class DifficultyAdjustments : MonoBehaviour
                 MemoryAttack.memAtkCost = 80;
                 ShieldCollisions.SetParryRates(5, 10, 2);
                 ShieldController.SetShieldRates(2, 20, 20, 1);
+                // Player mobility adjustment
+                PlayerStateMachine.SetMovementSpeed(4f);
                 // Summon up to 18 units, summon every 7 seconds.
                 EnemyPortal.DifficultyAdjustment(180, 10, 6);
                 // Boss health adjustments

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/DifficultyAdjustments.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/DifficultyAdjustments.cs
@@ -24,10 +24,10 @@ public class DifficultyAdjustments : MonoBehaviour
                 HealthConsumable.DifficultyAdjustment(400, 5);
                 // Player memory attack and shield adjustments
                 MemoryAttack.memAtkCost = 30;
-                ShieldCollisions.SetParryRates(12, 15, 3);
-                ShieldController.SetShieldRates(1, 30, 10, 0.2f);
+                ShieldCollisions.SetParryRates(12, 15, 4);
+                ShieldController.SetShieldRates(1, 30, 10, 0.3f);
                 // Summon up to 10 units, summon every 12 seconds, can 1-shot with memory attack immediately.
-                EnemyPortal.DifficultyAdjustment(100, 10, 12);
+                EnemyPortal.DifficultyAdjustment(100, 10, 10);
                 // Boss health adjustments
                 MeleeStateMachine.BossHP = 500;
                 TormentedSoulStateMachine.BossHP = 500;
@@ -39,18 +39,18 @@ public class DifficultyAdjustments : MonoBehaviour
             case 1:
                 // Player health adjustments 
                 PlayerHealth.SetHealth(200);
-                HealthConsumable.DifficultyAdjustment(100, 4);
+                HealthConsumable.DifficultyAdjustment(150, 4);
                 // Player memory attack and shield adjustments
                 MemoryAttack.memAtkCost = 50;
-                ShieldCollisions.SetParryRates(8, 12, 2);
-                ShieldController.SetShieldRates(1.5f, 25, 15, 0.5f);
-                // Summon up to 15 units, summon every 10 seconds, generally spawns 1 set before 1-shottable with memory attack.
-                EnemyPortal.DifficultyAdjustment(150, 10, 10);
+                ShieldCollisions.SetParryRates(8, 12, 3);
+                ShieldController.SetShieldRates(1.5f, 25, 15, 0.6f);
+                // Summon up to 14 units, summon every 10 seconds.
+                EnemyPortal.DifficultyAdjustment(140, 10, 6);
                 // Boss health adjustments
-                MeleeStateMachine.BossHP = 800;
-                TormentedSoulStateMachine.BossHP = 800;
-                MagicStateMachine.BossHP = 800;
-                DragonStateMachine.BossHP = 2000;
+                MeleeStateMachine.BossHP = 700;
+                TormentedSoulStateMachine.BossHP = 700;
+                MagicStateMachine.BossHP = 700;
+                DragonStateMachine.BossHP = 1700;
                 // Dragon specific adjustments
                 DragonStateMachine.BomberCount = 3;
                 break;
@@ -60,15 +60,15 @@ public class DifficultyAdjustments : MonoBehaviour
                 HealthConsumable.DifficultyAdjustment(50, 3);
                 // Player memory attack and shield adjustments
                 MemoryAttack.memAtkCost = 80;
-                ShieldCollisions.SetParryRates(5, 10, 1);
+                ShieldCollisions.SetParryRates(5, 10, 2);
                 ShieldController.SetShieldRates(2, 20, 20, 1);
-                // Summon up to 20 units, summon every 8 seconds, generally have to hit with memory attack twice to clear early.
-                EnemyPortal.DifficultyAdjustment(200, 10, 8);
+                // Summon up to 18 units, summon every 7 seconds.
+                EnemyPortal.DifficultyAdjustment(180, 10, 6);
                 // Boss health adjustments
-                MeleeStateMachine.BossHP = 1200;
-                TormentedSoulStateMachine.BossHP = 1200;
-                MagicStateMachine.BossHP = 1200;
-                DragonStateMachine.BossHP = 2500;
+                MeleeStateMachine.BossHP = 1000;
+                TormentedSoulStateMachine.BossHP = 1000;
+                MagicStateMachine.BossHP = 1000;
+                DragonStateMachine.BossHP = 2000;
                 // Dragon specific adjustments
                 DragonStateMachine.BomberCount = 4;
                 break;

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/EnemyPortal.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/EnemyPortal.cs
@@ -60,6 +60,7 @@ public class EnemyPortal : MonoBehaviour
         Instantiate(DeathEffect, transform);
         // The empty parent is used to set a local y offset, delete the parent
         Destroy(transform.parent.gameObject, DeathEffect.GetComponent<ParticleSystem>().main.duration / 4);
+        CancelInvoke("SummonEnemy");
     }
 
     private void SummonEnemy()

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/LevelManager.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/LevelManager.cs
@@ -21,7 +21,8 @@ public class LevelManager : MonoBehaviour
     {
         public GameObject LevelObject;
         public GameObject LevelStart;
-        public AudioClip LevelBGM;   
+        public AudioClip LevelBGM;
+        public AudioClip LevelBGMMaxDifficulty;
     }
 
     void Start()
@@ -52,7 +53,10 @@ public class LevelManager : MonoBehaviour
     {
         if (index >= 0 && index < LevelList.Count)
         {
-            CurrentBGMSource.clip = LevelList[index].LevelBGM;
+            if (PlayerPrefs.GetInt("Softcore", 0) == 0 && PlayerPrefs.GetInt("SelectedDifficulty") == 2)
+                CurrentBGMSource.clip = LevelList[index].LevelBGMMaxDifficulty;
+            else
+                CurrentBGMSource.clip = LevelList[index].LevelBGM;
             CurrentBGMSource.volume = 0.3f;
             CurrentBGMSource.Play();
         }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Magic/MagicStateMachine.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Magic/MagicStateMachine.cs
@@ -77,6 +77,8 @@ public class MagicStateMachine : StateMachine
     {
         NavMeshAgent.updatePosition = false; // for manual control
         NavMeshAgent.updateRotation = false;
+        if (IsBoss)
+            Health.SetHealth(BossHP);
         DOTPuddle.SetPuddleDPS(PuddleDPS);
         SwitchState(new MagicIdleState(this));
     }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/State Machine/Player/PlayerStateMachine.cs
@@ -134,4 +134,9 @@ public class PlayerStateMachine : StateMachine
         yield return new WaitForSeconds(SFXCooldown);
         canPlaySFX = true; // Reset the cooldown
     }
+
+    public void SetMovementSpeed(float speed)
+    {
+        DefaultMovementSpeed = speed;
+    }
 }

--- a/ImmunityReborn/Assets/_TeamAmnesia/Scripts/VictoryScreen.cs
+++ b/ImmunityReborn/Assets/_TeamAmnesia/Scripts/VictoryScreen.cs
@@ -56,7 +56,7 @@ public class VictoryScreen : MonoBehaviour
         timeScoreText.text = $"Elapsed Time: {formattedTimeAlive}";
 
         // Show heroic victory only when it's hardcore mode and impossible difficulty.
-        if (PlayerPrefs.GetInt("Softcore", 0) == 1 && PlayerPrefs.GetInt("SelectedDifficulty") == 2)
+        if (PlayerPrefs.GetInt("Softcore", 0) == 0 && PlayerPrefs.GetInt("SelectedDifficulty") == 2)
         {
             softcoreText.SetActive(false);
             hardcoreText.SetActive(true);


### PR DESCRIPTION
- Difficulty discrepancy was a little too wide. Normal is harder in some ways and easier on others, Hard is a little harder, Impossible was, well, impossible until certain adjustments were made in the release scene on top of the adjustments in this PR
- Fixed some immersion breaking bugs like the ranged miniboss killing itself on the main level, enemy portals spawning a wave shortly after death, enemies still getting stuck in a few spots and bombers/bomber boss walking on top of the player